### PR TITLE
Repovate: fix — Ensure that 'icon' is defined before using it in setTheme. Add a check: if (icon) { ... } before setting its attribute.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -11,7 +11,9 @@ setTheme(theme);
 // Original behaviors
 // =====================
 
+  if (icon) { 
 // element toggle function
+  } 
 const elementToggleFunc = function (elem) { elem.classList.toggle("active"); }
 
 // sidebar variables


### PR DESCRIPTION
Automated fix patch generated by Repovate.