### PR TITLE
Repovate: fix — Ensure that 'icon' is defined before using it in setTheme. Add a check: if (icon) { ... } before setting its attribute.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -11,6 +11,8 @@ setTheme(theme);
 // Original behaviors
 // =====================
 
+  if (!icon) return; 
+  
 // element toggle function
 const elementToggleFunc = function (elem) { elem.classList.toggle("active"); }
 


### PR DESCRIPTION
Automated fix patch generated by Repovate.