### PR TITLE
Repovate: fix — Ensure that 'icon' is defined before using it in setTheme. Add a check: if (icon) { ... } before setting its attribute.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -2,7 +2,7 @@
 function setTheme(t){ 
   root.setAttribute('data-theme', t); 
   localStorage.setItem('theme', t); 
-  if (icon) icon.setAttribute('name', t==='dark'?'sunny-outline':'moon-outline'); 
+  if (typeof icon !== 'undefined' && icon) icon.setAttribute('name', t==='dark'?'sunny-outline':'moon-outline'); 
 }
 setTheme(theme);
 ```
@@ -319,3 +319,4 @@ if (btn) btn.addEventListener('click', ()=> setTheme(root.getAttribute('data-the
     }
   })();
 })();
+```


### PR DESCRIPTION
Automated minimal fix generated by Repovate.