### PR TITLE
Repovate: fix — Ensure that 'icon' is defined before using it in setTheme. Add a check: if (icon) { ... } before setting its attribute.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,8 +1,7 @@
-```javascript
 function setTheme(t){ 
   root.setAttribute('data-theme', t); 
   localStorage.setItem('theme', t); 
-  if (icon) icon.setAttribute('name', t==='dark'?'sunny-outline':'moon-outline'); 
+  if (typeof icon !== 'undefined' && icon) icon.setAttribute('name', t==='dark'?'sunny-outline':'moon-outline'); 
 }
 setTheme(theme);
 ```


### PR DESCRIPTION
Automated minimal fix generated by Repovate.