### PR TITLE
Repovate: fix — Ensure 'icon' and 'btn' are defined before using them. Add null checks or default values to prevent potential runtime errors.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,7 +1,7 @@
 function setTheme(t){ 
   root.setAttribute('data-theme', t); 
   localStorage.setItem('theme', t); 
-  if (icon) icon.setAttribute('name', t==='dark'?'sunny-outline':'moon-outline'); 
+  if (typeof icon !== 'undefined' && icon) icon.setAttribute('name', t==='dark'?'sunny-outline':'moon-outline'); 
 }
 setTheme(theme);
 ```


### PR DESCRIPTION
Automated minimal fix generated by Repovate.